### PR TITLE
feat: extract inter-stage contracts to dedicated module

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 use crate::utils::indent_string;
+
 mod compile;
+mod contracts;
 mod lex;
 mod parse;
 
@@ -9,7 +11,7 @@ mod parse;
 pub enum InputError {
     LexError(String),
     ParseError(String),
-    CompileError(compile::ast::CompilationError),
+    CompileError(compile::CompilationError),
 }
 
 impl std::fmt::Display for InputError {

--- a/src/input/compile.rs
+++ b/src/input/compile.rs
@@ -1,13 +1,23 @@
+use crate::input::contracts::ast;
 use crate::output::{self};
 
-pub mod ast;
 mod set_attribute;
 mod transaction;
 
-pub fn compile_node(
-    node: &ast::ASTNode,
-    journal: &mut output::Journal,
-) -> ast::CompilationResult<()> {
+#[derive(Debug)]
+pub enum CompilationError {
+    GeneralError(String),
+}
+
+impl CompilationError {
+    pub fn from_str(s: &str) -> Self {
+        CompilationError::GeneralError(s.to_string())
+    }
+}
+
+pub type CompilationResult<T> = Result<T, CompilationError>;
+
+pub fn compile_node(node: &ast::ASTNode, journal: &mut output::Journal) -> CompilationResult<()> {
     match node {
         ast::ASTNode::Transaction(t) => transaction::TransactionCompiler::compile(t, journal),
         ast::ASTNode::SetAttribute(name, value) => {
@@ -16,7 +26,7 @@ pub fn compile_node(
     }
 }
 
-pub fn compile(nodes: Vec<ast::ASTNode>) -> ast::CompilationResult<output::Journal> {
+pub fn compile(nodes: Vec<ast::ASTNode>) -> CompilationResult<output::Journal> {
     let mut journal = output::Journal::default();
 
     for node in &nodes {

--- a/src/input/compile/set_attribute.rs
+++ b/src/input/compile/set_attribute.rs
@@ -1,4 +1,4 @@
-use crate::input::compile::ast::CompilationResult;
+use super::CompilationResult;
 use crate::output;
 
 pub struct SetAttributeCompiler;

--- a/src/input/contracts.rs
+++ b/src/input/contracts.rs
@@ -1,0 +1,2 @@
+pub mod ast;
+pub mod tokens;

--- a/src/input/contracts/ast.rs
+++ b/src/input/contracts/ast.rs
@@ -2,36 +2,27 @@ use chrono::{DateTime, FixedOffset};
 
 pub type Timestamp = DateTime<FixedOffset>;
 
+#[derive(Clone)]
 pub struct TransactionHeader {
     pub timestamp: Timestamp,
     pub attributes: serde_yaml::Mapping,
 }
 
+#[derive(Clone)]
 pub struct Posting {
     pub account: String,
     pub commodity: Option<String>,
     pub amount: Option<i64>,
 }
 
+#[derive(Clone)]
 pub struct Transaction {
     pub header: TransactionHeader,
     pub postings: Vec<Posting>,
 }
 
+#[derive(Clone)]
 pub enum ASTNode {
     Transaction(Transaction),
     SetAttribute(String, String),
 }
-
-#[derive(Debug)]
-pub enum CompilationError {
-    GeneralError(String),
-}
-
-impl CompilationError {
-    pub fn from_str(s: &str) -> Self {
-        CompilationError::GeneralError(s.to_string())
-    }
-}
-
-pub type CompilationResult<T> = Result<T, CompilationError>;

--- a/src/input/contracts/tokens.rs
+++ b/src/input/contracts/tokens.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, FixedOffset};
+
+pub type Timestamp = DateTime<FixedOffset>;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Keyword {
+    Set,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Token {
+    Keyword(Keyword),
+    Timestamp(Timestamp),
+    Amount(i64),
+    Identifier(String),
+    AccountSeparator,
+    PostingSeparator,
+    LineSeparator,
+    Comment(String),
+    YamlMatter(serde_yaml::Mapping),
+    Indent,
+    Dedent,
+}
+
+pub const TOKEN_NAME_KEYWORD: &str = "keyword";
+pub const TOKEN_NAME_TIMESTAMP: &str = "timestamp";
+pub const TOKEN_NAME_AMOUNT: &str = "amount";
+pub const TOKEN_NAME_IDENTIFIER: &str = "identifier";
+
+impl Token {
+    pub fn is_comment(&self) -> bool {
+        matches!(self, Token::Comment(_))
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Token::Keyword(_) => TOKEN_NAME_KEYWORD,
+            Token::Timestamp(_) => TOKEN_NAME_TIMESTAMP,
+            Token::Amount(_) => TOKEN_NAME_AMOUNT,
+            _ => "todo",
+        }
+    }
+}

--- a/src/input/lex.rs
+++ b/src/input/lex.rs
@@ -1,4 +1,4 @@
-use crate::input::parse::{Keyword, Token};
+use crate::input::contracts::tokens::{Keyword, Token};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::none_of;
@@ -131,8 +131,8 @@ pub fn lex_string(input: &str) -> LexResult<'_, Vec<Token>> {
 
 #[cfg(test)]
 mod test {
+    use crate::input::contracts::tokens::Token;
     use crate::input::lex::lex_string;
-    use crate::input::parse::Token;
 
     #[test]
     fn test_empty() {

--- a/src/input/lex/amount.rs
+++ b/src/input/lex/amount.rs
@@ -1,6 +1,6 @@
 use super::core::LexResult;
+use crate::input::contracts::tokens::Token;
 use crate::input::lex::whitespace;
-use crate::input::parse::Token;
 use nom::bytes::complete::tag;
 use nom::character::complete::{digit1, one_of};
 use nom::combinator::opt;

--- a/src/input/lex/identifier.rs
+++ b/src/input/lex/identifier.rs
@@ -1,6 +1,6 @@
 use super::core::LexResult;
+use crate::input::contracts::tokens::Token;
 use crate::input::lex::whitespace;
-use crate::input::parse::Token;
 use nom::bytes::complete::is_a;
 use nom::combinator::{opt, recognize};
 use nom::sequence::{pair, preceded};

--- a/src/input/lex/timestamp.rs
+++ b/src/input/lex/timestamp.rs
@@ -1,5 +1,5 @@
+use crate::input::contracts::tokens::{Timestamp, Token};
 use crate::input::lex::core::LexResult;
-use crate::input::parse::{Timestamp, Token};
 
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use nom::bytes::complete::take;

--- a/src/input/parse.rs
+++ b/src/input/parse.rs
@@ -1,13 +1,13 @@
-use crate::input::compile::ast;
+use crate::input::contracts::ast;
+use crate::input::contracts::tokens;
 
 mod core;
-pub use core::{Keyword, Parser, Timestamp, Token};
 mod set_attribute;
 mod transaction;
 
-use core::ParserResult;
+use core::{Parser, ParserResult};
 
-fn parse_comments(tokens: &[core::Token]) -> ParserResult<'_, ()> {
+fn parse_comments(tokens: &[tokens::Token]) -> ParserResult<'_, ()> {
     let mut rest = tokens;
 
     loop {
@@ -20,23 +20,23 @@ fn parse_comments(tokens: &[core::Token]) -> ParserResult<'_, ()> {
     Ok((rest, ()))
 }
 
-fn parse_transaction(tokens: &[core::Token]) -> ParserResult<'_, ast::ASTNode> {
+fn parse_transaction(tokens: &[tokens::Token]) -> ParserResult<'_, ast::ASTNode> {
     let (tokens, t) = transaction::TransactionParser::parse(tokens)?;
     Ok((tokens, ast::ASTNode::Transaction(t)))
 }
 
-fn parse_set_attribute(tokens: &[core::Token]) -> ParserResult<'_, ast::ASTNode> {
+fn parse_set_attribute(tokens: &[tokens::Token]) -> ParserResult<'_, ast::ASTNode> {
     let (tokens, (name, value)) = set_attribute::SetAttributeParser::new().parse(tokens)?;
     Ok((tokens, ast::ASTNode::SetAttribute(name, value)))
 }
 
-fn parse_node(tokens: &[core::Token]) -> ParserResult<'_, ast::ASTNode> {
+fn parse_node(tokens: &[tokens::Token]) -> ParserResult<'_, ast::ASTNode> {
     let parsers = [parse_transaction, parse_set_attribute];
     let result = core::one_of(&parsers).parse(tokens);
     result
 }
 
-pub fn parse_tokens(tokens: &[core::Token]) -> ParserResult<'_, Vec<ast::ASTNode>> {
+pub fn parse_tokens(tokens: &[tokens::Token]) -> ParserResult<'_, Vec<ast::ASTNode>> {
     let (tokens, _) = parse_comments(tokens)?;
 
     let mut rest = tokens;
@@ -54,7 +54,7 @@ pub fn parse_tokens(tokens: &[core::Token]) -> ParserResult<'_, Vec<ast::ASTNode
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::input::parse::core::Token;
+    use crate::input::parse::tokens::Token;
     use chrono::DateTime;
 
     #[test]

--- a/src/input/parse/core.rs
+++ b/src/input/parse/core.rs
@@ -1,32 +1,4 @@
-use chrono::{DateTime, FixedOffset};
-
-pub type Timestamp = DateTime<FixedOffset>;
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum Keyword {
-    Set,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum Token {
-    Keyword(Keyword),
-    Timestamp(Timestamp),
-    Amount(i64),
-    Identifier(String),
-    AccountSeparator,
-    PostingSeparator,
-    LineSeparator,
-    Comment(String),
-    YamlMatter(serde_yaml::Mapping),
-    Indent,
-    Dedent,
-}
-
-impl Token {
-    pub fn is_comment(&self) -> bool {
-        matches!(self, Token::Comment(_))
-    }
-}
+use crate::input::contracts::tokens::{Keyword, Timestamp, Token};
 
 pub type ParserResult<'a, T> = Result<(&'a [Token], T), String>;
 

--- a/src/input/parse/set_attribute.rs
+++ b/src/input/parse/set_attribute.rs
@@ -1,6 +1,5 @@
+use crate::input::contracts::tokens::{Keyword, Token};
 use crate::input::parse::core;
-use crate::input::parse::core::Keyword;
-use crate::input::parse::core::Token;
 
 pub struct SetAttributeParser;
 
@@ -22,7 +21,7 @@ impl SetAttributeParser {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::input::parse::{core::Keyword, Token};
+    use crate::input::contracts::tokens::{Keyword, Token};
 
     #[test]
     fn test_simple() {

--- a/src/input/parse/transaction.rs
+++ b/src/input/parse/transaction.rs
@@ -1,7 +1,7 @@
-use crate::input::compile::ast;
+use crate::input::contracts::ast;
+use crate::input::contracts::tokens::Token;
 use crate::input::parse::core;
 use crate::input::parse::core::Parser;
-use crate::input::parse::core::Token;
 
 pub struct TransactionParser;
 
@@ -81,7 +81,7 @@ impl TransactionParser {
 #[cfg(test)]
 mod test {
     use super::TransactionParser;
-    use crate::input::parse::core::{Timestamp, Token};
+    use crate::input::contracts::tokens::{Timestamp, Token};
 
     fn sample_timestamp() -> Timestamp {
         Timestamp::parse_from_rfc3339("2026-01-02T03:04:05.000+09:00").unwrap()


### PR DESCRIPTION
I want clearer separation between the different phases (lex/parse/compile), so I extracted the common parts into a contracts module.